### PR TITLE
Updated language-specific keys to 8.0

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -112,7 +112,7 @@ end
 
 -- Markdown-specific key commands.
 keys.markdown = {
-  [keys.LANGUAGE_MODULE_PREFIX] = {
+  [not OSX and not CURSES and 'cl' or 'ml'] = {
     -- Open this module for editing: `Alt/⌘-L` `M`
     m = { io.open_file,
         (_USERHOME..'/modules/markdown/init.lua') },


### PR DESCRIPTION
A quick update to the module, for it to work with 8.0 textadept, using the new [conversion rules](http://foicica.com/textadept/manual.html#Textadept.7.to.8) of `language-specific` key commands.
